### PR TITLE
Actualización de la url https a http

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,6 @@
 Repositorio con la documentación de Laravel PHP Framework en Español, actualmente se soporta la versión 4.1, 5.0 y 5.1.
 
 Puedes verla funcionando en:
-https://laravel.montogeek.com/
+http://laravel.montogeek.com/
 
 [![Build Status](https://snap-ci.com/montogeek/laravel-docs-es/branch/master/build_image)](https://snap-ci.com/montogeek/laravel-docs-es/branch/master)


### PR DESCRIPTION
Se actualizo la referencia de la url. Hacia referencia al protocolo https en vez de http. El enlace con protocolo https está roto.